### PR TITLE
Fix tests on windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -965,13 +965,17 @@ mod tests {
                 if extension.to_ascii_lowercase().as_str() == "png" {
                     let png_bytes = std::fs::read(&path).unwrap();
 
-                    let (_header, decoded) =
-                        if path.to_string_lossy().starts_with("test_pngs/png_suite/x") {
-                            assert!(decode(&png_bytes).is_err());
-                            continue;
-                        } else {
-                            decode(&png_bytes).unwrap()
-                        };
+                    let (_header, decoded) = if path
+                        .file_stem()
+                        .expect("expected png path to be a file")
+                        .to_string_lossy()
+                        .starts_with('x')
+                    {
+                        assert!(decode(&png_bytes).is_err());
+                        continue;
+                    } else {
+                        decode(&png_bytes).unwrap()
+                    };
 
                     // Uncomment to inspect output.png for debugging.
                     // let image_buf: image::ImageBuffer<image::Rgba<u8>, _> =


### PR DESCRIPTION
They were failing because the entire path was being converted to this string:

```

[src\lib.rs:968] path.to_string_lossy() = "test_pngs/png_suite\\xc1n0g08.png"

```

This instead just converts the filename part to a lossy string and checks that it starts with `x`