### PR TITLE
Make it fully `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ exclude = [
 ]
 
 [dependencies]
-crc32fast = "1"
-num_enum = { version = "0.5", features = [] }
-miniz_oxide = { version = "0.4", features = [] }
+crc32fast = { version = "1", default-features = false }
+num_enum = { version = "0.5", default-features = false }
+miniz_oxide = { version = "0.4", default-features = false }
 
 [dev-dependencies]
 image = { version = "0.23", features = ["png"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
 #![no_std]
 
+#[macro_use]
 extern crate alloc;
 
-#[macro_use]
+#[cfg(test)]
 extern crate std;
 
 use alloc::vec::Vec;


### PR DESCRIPTION
- Opt out of all default features in dependencies
- Don't `extern crate std;`