### PR TITLE
Update `miniz_oxide` and `num_enum` dependency (addresses RUSTSEC-2025-0056)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 
 [dependencies]
 crc32fast = { version = "1", default-features = false }
-num_enum = { version = "0.5", default-features = false }
+num_enum = { version = "0.7", default-features = false }
 miniz_oxide = { version = "0.8", default-features = false, features = ["with-alloc"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "png-decoder"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Brian Schwind <brianmschwind@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/bschwind/png-decoder"
@@ -19,7 +19,7 @@ exclude = [
 [dependencies]
 crc32fast = { version = "1", default-features = false }
 num_enum = { version = "0.5", default-features = false }
-miniz_oxide = { version = "0.4", default-features = false }
+miniz_oxide = { version = "0.8", default-features = false, features = ["with-alloc"] }
 
 [dev-dependencies]
 image = { version = "0.23", features = ["png"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -934,7 +934,9 @@ pub fn decode(bytes: &[u8]) -> Result<(PngHeader, Vec<u8>), DecodeError> {
     }
 
     let mut scanline_data = miniz_oxide::inflate::decompress_to_vec_zlib(&compressed_data)
-        .map_err(DecodeError::Decompress)?;
+        .map_err(|miniz_oxide::inflate::DecompressError { status, output: _ }| {
+            DecodeError::Decompress(status)
+        })?;
 
     // For now, output data is always RGBA, 1 byte per channel.
     let mut output_rgba = vec![0u8; header.width as usize * header.height as usize * 4];


### PR DESCRIPTION
As per https://rustsec.org/advisories/RUSTSEC-2025-0056, `adler` is unmaintained, and `png-decoder` has an indirect dependency on `adler` through `miniz_oxide`.

This PR updates `miniz_oxide` to 0.8, removing the dependency on `adler`. Since this is formally a breaking change (since the type of `DecodeError::Decompress`'s field changes), I also took the opportunity to update `num_enum` to 0.7 (also a breaking change, since which `TryFromPrimitive` is implemented changes).