### PR TITLE
Delete unused `pub struct Color`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,14 +505,6 @@ pub enum DecodeError {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct Color {
-    r: u8,
-    g: u8,
-    b: u8,
-    a: u8,
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ChunkType {
     ImageHeader,
     Palette,


### PR DESCRIPTION
Another cleanup that is technically a breaking change. The struct was completely unused inside the crate and unusable outside.

An alternative to this PR would be to use `Vec<Color>` in place of the returned `Vec<u8>`, but that would require several more `impl`s to be really usable.